### PR TITLE
Remove aws provider from module

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ This module creates an AWS auto-scaling group (ASG) and a network load balancer 
 ## Usage
 
 ```hcl
+provider "aws" {
+  region = "us-east-1"
+}
+
 module "aws_accesstier" {
   source                 = "banyansecurity/banyan-accesstier/aws"
   region                 = "us-east-1"

--- a/main.tf
+++ b/main.tf
@@ -1,8 +1,3 @@
-provider "aws" {
-  version = "~> 2.0"
-  region  = var.region
-}
-
 data aws_ami "default_ami" {
   most_recent = true
   owners      = ["amazon"]


### PR DESCRIPTION
Removing the provider allows us to pass in a provider from outside the module