### PR TITLE
Add pybanyan to user_data

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -111,7 +111,9 @@ resource aws_launch_configuration "conf" {
   user_data = join("", concat([
     "#!/bin/bash -ex\n",
     "yum update -y\n",
-    "yum install -y jq tar gzip curl sed\n",
+    "yum install -y jq tar gzip curl sed python3\n",
+    "pip3 install --upgrade pip\n",
+    "/usr/local/bin/pip3 install pybanyan\n", # previous line changes /bin/pip3 to /usr/local/bin which is not in the path
     "rpm --import https://www.banyanops.com/onramp/repo/RPM-GPG-KEY-banyan\n",
     "yum-config-manager --add-repo https://www.banyanops.com/onramp/repo\n",
     "yum install -y ${var.package_name} \n",


### PR DESCRIPTION
I had to upgrade pip in order to avoid the rust compile for cryptography.

The `pip3` upgrade command changes the `pip3` location from `/bin` to `/usr/local/bin` which is not in the `root` `$PATH`. I documented that in-line.