### PR TITLE
Output all resources

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -12,3 +12,58 @@ output "security_group_id" {
   value       = aws_security_group.sg.id
   description = "The ID of the security group, which can be added as an inbound rule on other backend groups (example: `sg-1234abcd`)"
 }
+
+output "sg" {
+  value       = aws_security_group.sg
+  description = "The `aws_security_group.sg` resource" 
+}
+
+output "asg" {
+  value       = aws_autoscaling_group.asg
+  description = "The `aws_autoscaling_group.asg` resource" 
+}
+
+output "conf" {
+  value       = aws_launch_configuration.conf
+  description = "The `aws_launch_configuration.conf` resource" 
+}
+
+output "nlb" {
+  value       = aws_alb.nlb
+  description = "The `aws_alb.nlb` resource" 
+}
+
+output "target443" {
+  value       = aws_lb_target_group.target443
+  description = "The `aws_lb_target_group.target443` resource" 
+}
+
+output "target8443" {
+  value       = aws_lb_target_group.target8443
+  description = "The `aws_lb_target_group.target8443` resource" 
+}
+
+output "target80" {
+  value       = aws_lb_target_group.target80
+  description = "The `aws_lb_target_group.target80` resource" 
+}
+
+output "listener443" {
+  value       = aws_lb_listener.listener443
+  description = "The `aws_lb_listener.listener443` resource" 
+}
+
+output "listener8443" {
+  value       = aws_lb_listener.listener8443
+  description = "The `aws_lb_listener.listener8443` resource" 
+}
+
+output "listener80" {
+  value       = aws_lb_listener.listener80
+  description = "The `aws_lb_listener.listener80` resource" 
+}
+
+output "cpu_policy" {
+  value       = aws_autoscaling_policy.cpu_policy
+  description = "The `aws_autoscaling_policy.cpu_policy` resource" 
+}


### PR DESCRIPTION
I originally wanted to access the target groups to create cloudwatch alarms.

Then I thought, why not have all the resources accessible?