### PR TITLE
Add max_instance_lifetime

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -81,6 +81,7 @@ resource "aws_autoscaling_group" "asg" {
   health_check_grace_period = 300
   health_check_type         = "ELB"
   target_group_arns         = compact([join("", aws_lb_target_group.target80.*.arn), aws_lb_target_group.target443.arn, aws_lb_target_group.target8443.arn])
+  max_instance_lifetime     = var.max_instance_lifetime
 
   dynamic "tag" {
     # do another merge for application specific tags if need-be

--- a/variables.tf
+++ b/variables.tf
@@ -163,3 +163,9 @@ variable "name_prefix" {
   description = "String to be added in front of all AWS object names"
   default     = "banyan"
 }
+
+variable "max_instance_lifetime" {
+  type        = number
+  default     = null
+  description = "The maximum amount of time, in seconds, that an instance can be in service, values must be either equal to 0 or between 604800 and 31536000 seconds"
+}


### PR DESCRIPTION
This allows auto rotation of our ASG by setting the maximum amount of time, in seconds, that an instance can be in service