### PR TITLE
Remove the launch configuration output to avoid latest terraform `sensitive` issues

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -23,11 +23,6 @@ output "asg" {
   description = "The `aws_autoscaling_group.asg` resource" 
 }
 
-output "conf" {
-  value       = aws_launch_configuration.conf
-  description = "The `aws_launch_configuration.conf` resource" 
-}
-
 output "nlb" {
   value       = aws_alb.nlb
   description = "The `aws_alb.nlb` resource" 


### PR DESCRIPTION
YAGNI

Closes https://github.com/banyansecurity/terraform-aws-banyan-accesstier/issues/17

There really isn't much of a purpose to return the launch configuration output. Better to remove it.